### PR TITLE
Update twist_filter.cpp

### DIFF
--- a/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/twist_filter/twist_filter.cpp
+++ b/ros/src/computing/planning/motion/packages/waypoint_follower/nodes/twist_filter/twist_filter.cpp
@@ -52,7 +52,7 @@ void TwistCmdCallback(const geometry_msgs::TwistStampedConstPtr &msg)
     return;
   }
 
-  double max_v = g_lateral_accel_limit / omega;
+  double max_v = g_lateral_accel_limit / fabs(omega);
 
   geometry_msgs::TwistStamped tp;
   tp.header = msg->header;


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
  In line 55 of twist_filter.cpp, “g_lateral_accel_limit” is always positive value, and when “omega” is negative value, the calculated “max_v” becomes negative, so “omega” should be added to the absolute value.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
roslaunch pkg_A executable_A
```
The car should move.